### PR TITLE
Updated Python bindings to work with Python 3.8 and above.

### DIFF
--- a/examples/python/ConsoleApp.py
+++ b/examples/python/ConsoleApp.py
@@ -23,9 +23,8 @@ print("Initializing Tolk...")
 Tolk.load()
 
 print("Querying for the active screen reader driver...")
-name = Tolk.detect_screen_reader()
-if name:
-  print("The active screen reader driver is: " + name)
+if name := Tolk.detect_screen_reader():
+  print(f'The active screen reader driver is: {name}')
 else:
   print("None of the supported screen readers is running\n")
 

--- a/src/python/Tolk.py
+++ b/src/python/Tolk.py
@@ -2,11 +2,16 @@
  #  Product:        Tolk
  #  File:           Tolk.py
  #  Description:    Python wrapper module.
- #  Copyright:      (c) 2014, Davy Kager <mail@davykager.nl>
+ #  Copyright:      (c) 2014-2021, Davy Kager <mail@davykager.nl>, Quin Marilyn <quin.marilyn05@gmail.com>
  #  License:        LGPLv3
  ##
 
 from ctypes import cdll, CFUNCTYPE, c_bool, c_wchar_p
+import os
+import sys
+
+if sys.version_info[1] >= 8:
+	os.add_dll_directory(os.getcwd())
 
 _tolk = cdll.Tolk
 


### PR DESCRIPTION
In Python 3.8 and above, the DLL loading mechanism has changed. We now have to get the current working directory (os.getcwd), and load Tolk from there if we're on 3.8 and above. I did that in this pull request. It works, and is already in production on [Quinter](http://github.com/QuinterApp).